### PR TITLE
Pull Request Title: RED-144408: Update Redis Enterprise Operator chart icon URL

### DIFF
--- a/charts/redis-enterprise-operator/Chart.yaml
+++ b/charts/redis-enterprise-operator/Chart.yaml
@@ -8,7 +8,7 @@ version: 7.8.2-6
 appVersion: 7.8.2-6
 
 home: https://redis.com
-icon: https://redis.com/wp-content/themes/wpx/assets/images/logo-redis.svg
+icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
 keywords:
   - redis
   - database


### PR DESCRIPTION

This change updates the icon URL in the `Chart.yaml` file for the Redis Enterprise Operator Helm chart.


- The `icon` field in `Chart.yaml` is updated to use a new URL: `https://redis.io/wp-content/uploads/2024/04/Logotype.svg`
- The previous icon URL (`https://redis.com/wp-content/themes/wpx/assets/images/logo-redis.svg`) is replaced with the new one.
- This update likely aims to use a more updated or preferred icon for the Redis Enterprise Operator Helm chart.