### PR TITLE
RED-145673: Update redis-enterprise-operator image repository

### DIFF
--- a/charts/redis-enterprise-operator/templates/_helpers.tpl
+++ b/charts/redis-enterprise-operator/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 {{ .registry }}/{{ .image }}@{{ .digest }}
 {{- end }}
 {{- else }}
-{{- $defaultRepository := ternary "registry.connect.redhat.com/redislabs/redis-enterprise-operator" "redislabs/operator-internal" .Values.openshift.mode }}
+{{- $defaultRepository := ternary "registry.connect.redhat.com/redislabs/redis-enterprise-operator" "redislabs/operator" .Values.openshift.mode }}
 {{- $repository := default $defaultRepository .Values.operator.image.repository }}
 {{ $repository }}:{{ .Values.operator.image.tag }}
 {{- end }}


### PR DESCRIPTION

- In the `_helpers.tpl` file, the `$defaultRepository` variable assignment for non-OpenShift mode was updated from `redislabs/operator-internal` to `redislabs/operator`.