### PR TITLE
MOD-14744: implement AI helm chart publishing flow

### DIFF
--- a/.github/workflows/ai-helm-lint.yaml
+++ b/.github/workflows/ai-helm-lint.yaml
@@ -1,0 +1,46 @@
+name: AI Helm Lint
+
+on:
+  pull_request:
+    paths:
+      - 'ai/**'
+      - '.github/workflows/ai-helm-lint.yaml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'ai/**'
+      - '.github/workflows/ai-helm-lint.yaml'
+
+jobs:
+  lint-ai-charts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.9.2
+
+      - name: Lint all AI Helm charts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chart_count=0
+
+          for chart_dir in ai/charts/*; do
+            if [[ -d "$chart_dir" && -f "$chart_dir/Chart.yaml" ]]; then
+              chart_count=$((chart_count + 1))
+              echo "Linting $chart_dir"
+              helm lint "$chart_dir"
+            fi
+          done
+
+          if [[ "$chart_count" -eq 0 ]]; then
+            echo "No AI charts found under ai/charts/"
+            exit 1
+          fi

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -1,0 +1,168 @@
+name: Release Helm Chart Reusable
+
+on:
+  workflow_call:
+    inputs:
+      chart_name:
+        description: Human-readable chart name for logs and workflow names.
+        required: true
+        type: string
+      chart_path:
+        description: Path to the chart directory, for example charts/my-chart.
+        required: true
+        type: string
+      tag_prefix:
+        description: Prefix for the git tag, for example my-chart.
+        required: true
+        type: string
+      release_command:
+        description: Slash command that triggers the release on a PR comment.
+        required: true
+        type: string
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      pull-requests: read
+
+    runs-on: ubuntu-latest
+    outputs:
+      changed_charts: ${{ steps.chart-releaser.outputs.changed_charts }}
+      chart_version: ${{ steps.extract-version.outputs.version }}
+
+    steps:
+      - name: Get PR details and check scope
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            if (pr.data.state !== 'open') {
+              core.setFailed('PR is not open. Cannot release.');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100
+            });
+
+            const chartPath = '${{ inputs.chart_path }}/';
+            const touchesChart = files.some(file => file.filename.startsWith(chartPath));
+            const filesOutsideChart = files
+              .map(file => file.filename)
+              .filter(filename => !filename.startsWith(chartPath));
+
+            if (!touchesChart) {
+              core.setFailed(`PR does not modify ${chartPath}. Refusing to release.`);
+              return;
+            }
+
+            if (filesOutsideChart.length > 0) {
+              core.setFailed(
+                `PR modifies files outside ${chartPath}: ${filesOutsideChart.join(', ')}. Refusing to release.`
+              );
+              return;
+            }
+
+            core.info(`Release command detected: ${{ inputs.release_command }}`);
+            core.setOutput('head_sha', pr.data.head.sha);
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Verify chart exists
+        run: |
+          test -f "${{ inputs.chart_path }}/Chart.yaml"
+
+      - name: Extract version from Helm chart metadata
+        id: extract-version
+        run: |
+          VERSION=$(grep '^version:' "${{ inputs.chart_path }}/Chart.yaml" | awk '{print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version for ${{ inputs.chart_name }}: $VERSION"
+
+      - name: Create and push release tag
+        run: |
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          TAG_NAME="${{ inputs.tag_prefix }}-$VERSION"
+
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+          echo "Created and pushed tag: $TAG_NAME"
+
+      - name: Prepare isolated chart directory
+        run: |
+          rm -rf .release-charts
+          mkdir -p .release-charts
+          cp -R "${{ inputs.chart_path }}" ".release-charts/${{ inputs.tag_prefix }}"
+
+      - name: Write chart releaser config
+        run: |
+          cat > cr.yaml <<'EOF'
+          pages-index-path: ai/index.yaml
+          pages-branch: gh-pages
+          release-name-template: '{{ .Name }}-{{ .Version }}'
+          EOF
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.9.2
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1
+        id: chart-releaser
+        with:
+          charts_dir: .release-charts
+          package_path: .cr-release-packages
+          config: cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    needs:
+      - release
+    if: needs.release.outputs.changed_charts != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-redis-agent-memory.yaml
+++ b/.github/workflows/release-redis-agent-memory.yaml
@@ -1,0 +1,19 @@
+name: Release Redis Agent Memory Chart
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-release-workflow:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/release-redis-agent-memory') &&
+      github.event.issue.state == 'open'
+    uses: ./.github/workflows/release-chart-reusable.yaml
+    with:
+      chart_name: redis-agent-memory
+      chart_path: ai/charts/redis-agent-memory
+      tag_prefix: redis-agent-memory
+      release_command: /release-redis-agent-memory
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This Git repository is a monorepo containing separate Helm repositories. The existing Redis Enterprise Helm repo lives under `charts/`, with the operator chart at `charts/redis-enterprise-operator/`. The AI Helm repo lives under `ai/`, starting with `ai/charts/redis-agent-memory/`. Chart metadata belongs in `Chart.yaml`, defaults in `values.yaml`, docs in `README.md`, and rendered resources in `templates/`. Keep AI and non-AI chart content isolated.
+
+## Build, Test, and Development Commands
+
+Use Helm CLI commands against the specific chart path you are changing:
+
+- `helm lint charts/redis-enterprise-operator` validates chart structure and templates.
+- `helm lint ai/charts/redis-agent-memory` validates the AI chart.
+- `helm template redis-enterprise-operator charts/redis-enterprise-operator` renders the operator chart locally.
+- `helm template redis-agent-memory ai/charts/redis-agent-memory` renders the AI chart locally.
+- `helm package <chart-path>` builds a distributable chart archive for a single chart.
+
+For local verification, render with realistic overrides when needed, for example:
+`helm template test charts/redis-enterprise-operator --set openshift.mode=true`.
+
+## Coding Style & Naming Conventions
+
+Write YAML and Helm templates with two-space indentation. Keep values keys lowercase camelCase, matching established patterns such as `imagePullSecrets`, `limitToNamespace`, and `operator.image.tag`. Template filenames should describe the resource they render. Reuse chart-local helpers rather than duplicating naming or annotation logic across repositories.
+
+## Testing Guidelines
+
+There is no dedicated test suite checked in, so treat `helm lint` and `helm template` as the baseline gate for every change. Validate only the chart you are changing. For AI releases, changes must stay inside `ai/charts/<chart-name>/` unless the work explicitly targets shared AI release workflow files. For operator changes, verify affected feature flags such as OpenShift mode and inspect rendered CRDs or jobs directly.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short imperative subjects such as `promoting version 8.0.16-25 (#38)`. Keep commit messages concise and scoped to a single chart or workflow change. Use `git town` when configured for the repo; otherwise use plain Git commands. PRs should explain which Helm repository is affected, note any value or release-flow changes, and include validation commands. Release triggers are chart-specific: `/release` for the Redis Enterprise operator flow and `/release-redis-agent-memory` for the AI chart flow.
+
+## Agent-Specific Notes
+
+Follow any rules defined under `.augment/rules/` when present in this repository or its subprojects. Do not introduce unrelated tooling or repo-wide conventions unless they are already in use here.

--- a/ai/charts/redis-agent-memory/.helmignore
+++ b/ai/charts/redis-agent-memory/.helmignore
@@ -1,0 +1,13 @@
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~

--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+type: application
+
+name: redis-agent-memory
+description: Placeholder Helm chart for Redis Agent Memory
+
+version: 0.0.0
+appVersion: 0.0.0
+
+home: https://redis.io
+icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
+keywords:
+  - redis
+  - memory
+maintainers:
+  - name: Redis
+    url: https://redis.io

--- a/ai/charts/redis-agent-memory/README.md
+++ b/ai/charts/redis-agent-memory/README.md
@@ -1,0 +1,3 @@
+# Redis Agent Memory Helm Chart
+
+Placeholder chart used to bootstrap release automation for `redis-agent-memory`.

--- a/ai/charts/redis-agent-memory/templates/NOTES.txt
+++ b/ai/charts/redis-agent-memory/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Redis Agent Memory placeholder chart.

--- a/ai/charts/redis-agent-memory/values.yaml
+++ b/ai/charts/redis-agent-memory/values.yaml
@@ -1,0 +1,3 @@
+# Placeholder values for the redis-agent-memory chart.
+#
+# Add chart configuration here as templates are introduced.

--- a/docs/ai-helm-repo-spec.md
+++ b/docs/ai-helm-repo-spec.md
@@ -1,0 +1,143 @@
+# AI Helm Repository Spec
+
+## Purpose
+
+This document defines the target design for a dedicated Helm repository for AI-related products. The goal is to isolate AI chart ownership and release flow from unrelated product teams and repositories.
+
+This git monorepo already contains a Helm repository for Redis Enterprise. The AI Helm repository will live alongside it as a separate Helm repository rooted under `ai/`.
+
+## Scope
+
+The new repository will host Helm charts for AI products only. It is expected to start with `redis-agent-memory` and may later include additional AI-owned charts if they share the same department, release governance, and publication destination.
+
+This spec does not cover application image build pipelines. It covers chart source layout, validation, release gating, and Helm repository publication.
+
+## Chart Repository Model
+
+The monorepo contains multiple Helm repositories. The AI Helm repository is a dedicated area for AI-owned charts and must not contain non-AI product charts.
+
+Initial structure to accommodate AI-owned charts:
+
+```text
+.github/
+  workflows/
+ai/charts/
+  redis-agent-memory/
+```
+
+Each chart directory must contain at least:
+
+- `Chart.yaml`
+- `values.yaml`
+- `README.md`
+- `templates/` when the chart begins rendering resources
+
+## Ownership and Change Boundaries
+
+Each chart release PR must be chart-scoped.
+
+Required rules:
+
+- By default, the release workflow should fail if a release-triggered PR changes files outside `ai/charts/<chart-name>/`.
+- CODEOWNERS should list the AI team members that are responsible for the AI chart repository.
+
+## Versioning
+
+Chart version is the source of truth for releases.
+
+Rules:
+
+- Release automation reads `version:` from `ai/charts/<chart-name>/Chart.yaml`.
+- Git tag format is `<chart-name>-<version>`.
+- `appVersion` may differ from chart version, but chart release automation keys off `version` only.
+
+Example:
+
+- Chart: `redis-agent-memory`
+- Version: `0.3.4`
+- Tag: `redis-agent-memory-0.3.4`
+
+## Release Trigger
+
+Each chart uses an explicit slash-command trigger on a pull request comment.
+
+For `redis-agent-memory`, the release trigger is:
+
+```text
+/release-redis-agent-memory
+```
+
+Trigger requirements:
+
+- The comment must be on a PR, not an issue.
+- The PR must be open.
+- The PR diff must be restricted to the target chart path.
+
+The workflow must fail fast with a clear error if any condition is not satisfied.
+
+## Release Workflow
+
+The release implementation should use a reusable workflow plus thin product-specific wrappers.
+
+Required behavior:
+
+1. Wrapper workflow listens for the chart-specific slash command.
+2. Reusable workflow validates PR state and changed-file scope.
+3. Workflow checks out the PR head SHA.
+4. Workflow reads the chart version from `Chart.yaml`.
+5. Workflow creates and pushes the chart-specific Git tag.
+6. Workflow packages and publishes only the target chart.
+7. Workflow updates the Helm repository index and any generated HTML landing page if used.
+
+The packaging step must isolate the target chart so multi-chart repo growth does not accidentally release unrelated charts.
+
+## Validation Requirements
+
+Minimum validation before release:
+
+- `helm lint ai/charts/<chart-name>`
+- `helm template <release-name> ai/charts/<chart-name>` for render validation
+
+If templates or values files are still placeholders, lint warnings may be allowed, but lint or template failures must block release.
+
+## Publication Model
+
+The AI Helm repository is published separately from the existing Redis Enterprise Helm repository, even though both live in the same git monorepo.
+
+The publication target uses GitHub Pages plus the reusable release workflow in `.github/workflows/release-chart-reusable.yaml`. That workflow is based on the existing `.github/workflows/release.yaml` flow, but it must publish AI chart artifacts and index content into a separate AI repository under `gh-pages/ai/`.
+
+Required publication behavior:
+
+- versioned `.tgz` chart packages are published for AI charts only
+- an AI-specific `index.yaml` is maintained under `gh-pages/ai/`
+- optional landing content such as `gh-pages/ai/index.html` may be generated
+- release artifacts are attached to GitHub releases
+- release artifacts are immutable once published
+
+The implementation must not overwrite or regenerate the existing Redis Enterprise Helm repository index as part of an AI chart release.
+
+Implementation requirement:
+
+- `.github/workflows/release-chart-reusable.yaml` is the mechanism that packages the target AI chart, updates `gh-pages/ai/index.yaml`, and writes any optional AI landing-page content.
+- The reusable AI release flow must preserve the current Redis Enterprise release behavior defined in `.github/workflows/release.yaml`.
+
+## Non-Goals
+
+The release workflow must not:
+
+- release all charts in the repository by default
+- infer the target chart from any changed folder automatically without an explicit trigger
+- share a generic `/release` command across unrelated products
+
+## Acceptance Criteria
+
+The implementation is complete when:
+
+- the AI repository lives under `ai/` and is clearly separated from the existing Redis Enterprise Helm repository
+- the existing Redis Enterprise chart contents and release behavior remain unchanged
+- `ai/charts/redis-agent-memory` exists as a valid chart
+- a chart-scoped release workflow exists for `redis-agent-memory`
+- the workflow fails if the PR touches files outside `ai/charts/redis-agent-memory/`
+- the workflow tags releases as `redis-agent-memory-<version>`
+- only the target chart is packaged and published
+- the AI Helm repository publishes its own `gh-pages/ai/index.yaml` without modifying the Redis Enterprise Helm repository index


### PR DESCRIPTION
## Summary
- add an AI-specific reusable chart release workflow that publishes `gh-pages/ai/index.yaml`
- add the `redis-agent-memory` wrapper workflow and placeholder chart under `ai/charts/`
- capture the AI Helm repository model and release contract in `docs/ai-helm-repo-spec.md`

## Validation
- `helm lint ai/charts/redis-agent-memory`

Jira: https://redislabs.atlassian.net/browse/MOD-14744