### PR TITLE
test: release redis-agent-memory 0.0.1

### DIFF
--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -28,7 +28,6 @@ jobs:
 
     runs-on: ubuntu-latest
     outputs:
-      changed_charts: ${{ steps.chart-releaser.outputs.changed_charts }}
       chart_version: ${{ steps.extract-version.outputs.version }}
 
     steps:
@@ -103,6 +102,11 @@ jobs:
           VERSION="${{ steps.extract-version.outputs.version }}"
           TAG_NAME="${{ inputs.tag_prefix }}-$VERSION"
 
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists locally"
+            exit 1
+          fi
+
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 
@@ -117,6 +121,7 @@ jobs:
       - name: Write chart releaser config
         run: |
           cat > cr.yaml <<'EOF'
+          package-path: .cr-release-packages
           pages-index-path: ai/index.yaml
           pages-branch: gh-pages
           release-name-template: '{{ .Name }}-{{ .Version }}'
@@ -127,42 +132,41 @@ jobs:
         with:
           version: v3.9.2
 
-      - name: Run chart-releaser
+      - name: Install chart releaser
         uses: helm/chart-releaser-action@v1
-        id: chart-releaser
         with:
-          charts_dir: .release-charts
-          package_path: .cr-release-packages
+          install_only: true
           config: cr.yaml
         env:
           CR_TOKEN: "${{ github.token }}"
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      pages: write
-    needs:
-      - release
-    if: needs.release.outputs.changed_charts != ''
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          fetch-depth: 0
+      - name: Package chart
+        run: |
+          cr package ".release-charts/${{ inputs.tag_prefix }}" --config cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+      - name: Upload chart release
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr upload \
+            --owner "$owner" \
+            --git-repo "$repo" \
+            --commit "${{ steps.pr.outputs.head_sha }}" \
+            --skip-existing \
+            --config cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: .
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Update AI Helm repository index
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr index \
+            --owner "$owner" \
+            --git-repo "$repo" \
+            --push \
+            --config cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -201,3 +201,32 @@ jobs:
             --config cr.yaml
         env:
           CR_TOKEN: "${{ github.token }}"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    needs:
+      - release
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -192,6 +192,7 @@ jobs:
         run: |
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          git fetch origin gh-pages
           mkdir -p .cr-index/ai
           cr index \
             --owner "$owner" \

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -127,6 +127,7 @@ jobs:
       - name: Write chart releaser config
         run: |
           cat > cr.yaml <<'EOF'
+          index-path: .cr-index/ai/index.yaml
           package-path: .cr-release-packages
           pages-index-path: ai/index.yaml
           pages-branch: gh-pages
@@ -169,6 +170,7 @@ jobs:
         run: |
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          mkdir -p .cr-index/ai
           cr index \
             --owner "$owner" \
             --git-repo "$repo" \

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -19,6 +19,11 @@ on:
         description: Slash command that triggers the release on a PR comment.
         required: true
         type: string
+      pr_number:
+        description: Pull request number to release. Used by manual workflow_dispatch testing.
+        required: false
+        default: ""
+        type: string
 
 jobs:
   release:
@@ -36,10 +41,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const prNumber = Number('${{ inputs.pr_number }}' || context.issue.number);
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: prNumber
             });
 
             if (pr.data.state !== 'open') {
@@ -50,7 +56,7 @@ jobs:
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: prNumber,
               per_page: 100
             });
 

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -166,6 +166,28 @@ jobs:
         env:
           CR_TOKEN: "${{ github.token }}"
 
+      - name: Ensure AI Pages directory exists
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          git clone --branch gh-pages --depth 1 \
+            "https://x-access-token:${CR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$tmpdir"
+
+          mkdir -p "$tmpdir/ai"
+          touch "$tmpdir/ai/.gitkeep"
+
+          if [[ -n "$(git -C "$tmpdir" status --short)" ]]; then
+            git -C "$tmpdir" config user.name "$GITHUB_ACTOR"
+            git -C "$tmpdir" config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git -C "$tmpdir" add ai/.gitkeep
+            git -C "$tmpdir" commit -m "Initialize AI Helm repository directory"
+            git -C "$tmpdir" push origin gh-pages
+          fi
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
       - name: Update AI Helm repository index
         run: |
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")

--- a/.github/workflows/release-redis-agent-memory.yaml
+++ b/.github/workflows/release-redis-agent-memory.yaml
@@ -8,12 +8,12 @@ jobs:
   call-release-workflow:
     if: |
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/release-redis-agent-memory') &&
+      contains(github.event.comment.body, '/publish-redis-agent-memory') &&
       github.event.issue.state == 'open'
     uses: ./.github/workflows/release-chart-reusable.yaml
     with:
       chart_name: redis-agent-memory
       chart_path: ai/charts/redis-agent-memory
       tag_prefix: redis-agent-memory
-      release_command: /release-redis-agent-memory
+      release_command: /publish-redis-agent-memory
     secrets: inherit

--- a/.github/workflows/release-redis-agent-memory.yaml
+++ b/.github/workflows/release-redis-agent-memory.yaml
@@ -3,17 +3,27 @@ name: Release Redis Agent Memory Chart
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to release manually for testing.
+        required: true
+        type: string
 
 jobs:
   call-release-workflow:
     if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/publish-redis-agent-memory') &&
-      github.event.issue.state == 'open'
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/publish-redis-agent-memory') &&
+        github.event.issue.state == 'open'
+      )
     uses: ./.github/workflows/release-chart-reusable.yaml
     with:
       chart_name: redis-agent-memory
       chart_path: ai/charts/redis-agent-memory
       tag_prefix: redis-agent-memory
       release_command: /publish-redis-agent-memory
+      pr_number: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
     secrets: inherit

--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 name: redis-agent-memory
 description: Placeholder Helm chart for Redis Agent Memory
 
-version: 0.0.0
-appVersion: 0.0.0
+version: 0.0.1
+appVersion: 0.0.1
 
 home: https://redis.io
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg


### PR DESCRIPTION
## Summary
- bump the `redis-agent-memory` chart version from `0.0.0` to `0.0.1`
- keep the PR chart-scoped so it satisfies the AI release workflow guardrails

## Validation
- `helm lint ai/charts/redis-agent-memory`

This PR is intended to test the AI Helm chart release process via `/release-redis-agent-memory`.