### PR TITLE
test: verify redis-agent-memory release 0.0.2

### DIFF
--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -19,6 +19,11 @@ on:
         description: Slash command that triggers the release on a PR comment.
         required: true
         type: string
+      pr_number:
+        description: Pull request number to release. Used by manual workflow_dispatch testing.
+        required: false
+        default: ""
+        type: string
 
 jobs:
   release:
@@ -36,10 +41,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const prNumber = Number('${{ inputs.pr_number }}' || context.issue.number);
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: prNumber
             });
 
             if (pr.data.state !== 'open') {
@@ -50,7 +56,7 @@ jobs:
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: prNumber,
               per_page: 100
             });
 

--- a/.github/workflows/release-redis-agent-memory.yaml
+++ b/.github/workflows/release-redis-agent-memory.yaml
@@ -3,17 +3,27 @@ name: Release Redis Agent Memory Chart
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to release manually for testing.
+        required: true
+        type: string
 
 jobs:
   call-release-workflow:
     if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/publish-redis-agent-memory') &&
-      github.event.issue.state == 'open'
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/publish-redis-agent-memory') &&
+        github.event.issue.state == 'open'
+      )
     uses: ./.github/workflows/release-chart-reusable.yaml
     with:
       chart_name: redis-agent-memory
       chart_path: ai/charts/redis-agent-memory
       tag_prefix: redis-agent-memory
       release_command: /publish-redis-agent-memory
+      pr_number: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
     secrets: inherit

--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 name: redis-agent-memory
 description: Placeholder Helm chart for Redis Agent Memory
 
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 
 home: https://redis.io
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg


### PR DESCRIPTION
## Summary
- bump the `redis-agent-memory` chart version from `0.0.1` to `0.0.2`
- verify the fixed AI issue-comment release workflow against a base branch that already contains the workflow changes

## Validation
- `helm lint ai/charts/redis-agent-memory`

This PR exists only to verify the AI Helm chart release flow end-to-end via `/publish-redis-agent-memory`.