### PR TITLE
test: verify chart-scoped redis-agent-memory release 0.0.5

### DIFF
--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -192,6 +192,7 @@ jobs:
         run: |
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          git fetch origin gh-pages
           mkdir -p .cr-index/ai
           cr index \
             --owner "$owner" \

--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 name: redis-agent-memory
 description: Placeholder Helm chart for Redis Agent Memory
 
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 
 home: https://redis.io
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg


### PR DESCRIPTION
## Summary
- bump the `redis-agent-memory` chart version from `0.0.4` to `0.0.5`
- keep the PR strictly chart-scoped so it satisfies the AI release workflow guardrails
- verify the AI Pages bootstrap and nested index publication path

## Validation
- `helm lint ai/charts/redis-agent-memory`

This PR exists only to verify the AI Helm chart release flow via manual dispatch against a chart-only PR.