### PR TITLE
test: verify chart-scoped redis-agent-memory release 0.0.6

### DIFF
--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 name: redis-agent-memory
 description: Placeholder Helm chart for Redis Agent Memory
 
-version: 0.0.5
-appVersion: 0.0.5
+version: 0.0.6
+appVersion: 0.0.6
 
 home: https://redis.io
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg


### PR DESCRIPTION
## Summary
- bump the `redis-agent-memory` chart version from `0.0.5` to `0.0.6`
- keep the PR strictly chart-scoped so it satisfies the AI release workflow guardrails
- verify the refreshed gh-pages ref during AI index publication

## Validation
- `helm lint ai/charts/redis-agent-memory`

This PR exists only to verify the AI Helm chart release flow via manual dispatch against a chart-only PR.