### PR TITLE
test: verify public redis-agent-memory release 0.0.8

### DIFF
--- a/ai/charts/redis-agent-memory/Chart.yaml
+++ b/ai/charts/redis-agent-memory/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 name: redis-agent-memory
 description: Placeholder Helm chart for Redis Agent Memory
 
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.8
+appVersion: 0.0.8
 
 home: https://redis.io
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg


### PR DESCRIPTION
## Summary
- bump the `redis-agent-memory` chart version from `0.0.1` to `0.0.8`
- keep the PR strictly chart-scoped so it satisfies the AI release workflow guardrails
- verify the public AI Helm repo publication at `https://helm.redis.io/ai`

## Validation
- `helm lint ai/charts/redis-agent-memory`

This PR exists only to verify the AI Helm chart release flow and public-site publishing via manual dispatch against a chart-only PR.