### PR TITLE
Add manual AI Helm release workflow

### DIFF
--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     outputs:
-      changed_charts: ${{ steps.chart-releaser.outputs.changed_charts }}
+      changed_charts: ${{ steps.publish-index.outputs.changed_charts }}
       chart_version: ${{ steps.extract-version.outputs.version }}
 
     steps:
@@ -68,6 +68,8 @@ jobs:
       - name: Write chart releaser config
         run: |
           cat > cr.yaml <<'EOF'
+          index-path: .cr-index/ai/index.yaml
+          package-path: .cr-release-packages
           pages-index-path: ai/index.yaml
           pages-branch: gh-pages
           release-name-template: '{{ .Name }}-{{ .Version }}'
@@ -78,13 +80,68 @@ jobs:
         with:
           version: v3.9.2
 
-      - name: Run chart-releaser
+      - name: Install chart releaser
         uses: helm/chart-releaser-action@v1
-        id: chart-releaser
         with:
-          charts_dir: .release-charts
-          package_path: .cr-release-packages
+          install_only: true
           config: cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
+      - name: Package chart
+        run: |
+          cr package ".release-charts/${{ inputs.tag_prefix }}" --config cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
+      - name: Upload chart release
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr upload \
+            --owner "$owner" \
+            --git-repo "$repo" \
+            --commit "${{ github.sha }}" \
+            --skip-existing \
+            --config cr.yaml
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
+      - name: Ensure AI Pages directory exists
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          git clone --branch gh-pages --depth 1 \
+            "https://x-access-token:${CR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$tmpdir"
+
+          mkdir -p "$tmpdir/ai"
+          touch "$tmpdir/ai/.gitkeep"
+
+          if [[ -n "$(git -C "$tmpdir" status --short)" ]]; then
+            git -C "$tmpdir" config user.name "$GITHUB_ACTOR"
+            git -C "$tmpdir" config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git -C "$tmpdir" add ai/.gitkeep
+            git -C "$tmpdir" commit -m "Initialize AI Helm repository directory"
+            git -C "$tmpdir" push origin gh-pages
+          fi
+        env:
+          CR_TOKEN: "${{ github.token }}"
+
+      - name: Update AI Helm repository index
+        id: publish-index
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          git fetch origin gh-pages
+          mkdir -p .cr-index/ai
+          cr index \
+            --owner "$owner" \
+            --git-repo "$repo" \
+            --push \
+            --config cr.yaml
+          echo "changed_charts=${{ inputs.chart_name }}" >> "$GITHUB_OUTPUT"
         env:
           CR_TOKEN: "${{ github.token }}"
 

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -27,6 +27,13 @@ jobs:
       chart_version: ${{ steps.extract-version.outputs.version }}
 
     steps:
+      - name: Verify workflow runs from master
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "master" ]; then
+            echo "This workflow can only be run from master. Current ref: ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-chart-reusable.yaml
+++ b/.github/workflows/release-chart-reusable.yaml
@@ -15,16 +15,11 @@ on:
         description: Prefix for the git tag, for example my-chart.
         required: true
         type: string
-      release_command:
-        description: Slash command that triggers the release on a PR comment.
-        required: true
-        type: string
 
 jobs:
   release:
     permissions:
       contents: write
-      pull-requests: read
 
     runs-on: ubuntu-latest
     outputs:
@@ -32,55 +27,11 @@ jobs:
       chart_version: ${{ steps.extract-version.outputs.version }}
 
     steps:
-      - name: Get PR details and check scope
-        id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            if (pr.data.state !== 'open') {
-              core.setFailed('PR is not open. Cannot release.');
-              return;
-            }
-
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 100
-            });
-
-            const chartPath = '${{ inputs.chart_path }}/';
-            const touchesChart = files.some(file => file.filename.startsWith(chartPath));
-            const filesOutsideChart = files
-              .map(file => file.filename)
-              .filter(filename => !filename.startsWith(chartPath));
-
-            if (!touchesChart) {
-              core.setFailed(`PR does not modify ${chartPath}. Refusing to release.`);
-              return;
-            }
-
-            if (filesOutsideChart.length > 0) {
-              core.setFailed(
-                `PR modifies files outside ${chartPath}: ${filesOutsideChart.join(', ')}. Refusing to release.`
-              );
-              return;
-            }
-
-            core.info(`Release command detected: ${{ inputs.release_command }}`);
-            core.setOutput('head_sha', pr.data.head.sha);
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release-redis-agent-memory.yaml
+++ b/.github/workflows/release-redis-agent-memory.yaml
@@ -1,19 +1,13 @@
 name: Release Redis Agent Memory Chart
 
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   call-release-workflow:
-    if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/release-redis-agent-memory') &&
-      github.event.issue.state == 'open'
     uses: ./.github/workflows/release-chart-reusable.yaml
     with:
       chart_name: redis-agent-memory
       chart_path: ai/charts/redis-agent-memory
       tag_prefix: redis-agent-memory
-      release_command: /release-redis-agent-memory
     secrets: inherit

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,65 @@
+# AI Helm Repository
+
+This directory contains the AI-owned Helm charts in this monorepo.
+
+Current chart layout:
+
+- `ai/charts/redis-agent-memory`
+
+## Making Changes
+
+Update only the target chart directory for normal chart work.
+
+Typical files:
+
+- `Chart.yaml` for chart metadata and `version`
+- `values.yaml` for defaults
+- `templates/` for rendered Kubernetes resources
+- `README.md` for chart-specific usage notes
+
+When preparing a release, bump `version:` in `ai/charts/<chart-name>/Chart.yaml`. The Git tag is derived from that value as `<chart-name>-<version>`.
+
+## Local Validation
+
+Run validation before opening or merging changes:
+
+```bash
+helm lint ai/charts/redis-agent-memory
+helm template redis-agent-memory ai/charts/redis-agent-memory
+```
+
+If the chart adds templates, make sure rendered output matches the expected resources and values.
+
+## Release Process
+
+AI chart releases are manual and run only from `master`.
+
+Current release workflow:
+
+- workflow: `.github/workflows/release-redis-agent-memory.yaml`
+- chart: `ai/charts/redis-agent-memory`
+- publication target: `gh-pages/ai/index.yaml`
+
+Release steps:
+
+1. Merge the chart change to `master`.
+2. Confirm the desired chart version in `ai/charts/redis-agent-memory/Chart.yaml`.
+3. In GitHub Actions, run `Release Redis Agent Memory Chart`.
+4. Select the `master` branch when dispatching the workflow.
+
+The workflow will:
+
+- read the chart version from `Chart.yaml`
+- create the tag `redis-agent-memory-<version>`
+- package and publish the chart
+- update the AI Helm repository index under `gh-pages/ai/`
+
+## Consuming The Repo
+
+Consumers can add the AI Helm repository with:
+
+```bash
+helm repo add redis-ai https://helm.redis.io/ai
+helm repo update redis-ai
+helm search repo redis-ai/redis-agent-memory --versions
+```

--- a/docs/ai-helm-repo-spec.md
+++ b/docs/ai-helm-repo-spec.md
@@ -34,12 +34,7 @@ Each chart directory must contain at least:
 
 ## Ownership and Change Boundaries
 
-Each chart release PR must be chart-scoped.
-
-Required rules:
-
-- By default, the release workflow should fail if a release-triggered PR changes files outside `ai/charts/<chart-name>/`.
-- CODEOWNERS should list the AI team members that are responsible for the AI chart repository.
+CODEOWNERS should list the AI team members that are responsible for the AI chart repository.
 
 ## Versioning
 
@@ -59,21 +54,17 @@ Example:
 
 ## Release Trigger
 
-Each chart uses an explicit slash-command trigger on a pull request comment.
+Each chart uses an explicit manual release workflow.
 
-For `redis-agent-memory`, the release trigger is:
-
-```text
-/release-redis-agent-memory
-```
+For `redis-agent-memory`, the release workflow is started with `workflow_dispatch`.
 
 Trigger requirements:
 
-- The comment must be on a PR, not an issue.
-- The PR must be open.
-- The PR diff must be restricted to the target chart path.
+- the workflow must be manually triggered
+- the selected ref must be `master`
+- the released chart content comes from `master`
 
-The workflow must fail fast with a clear error if any condition is not satisfied.
+The workflow must fail fast with a clear error if it is triggered from any branch other than `master`.
 
 ## Release Workflow
 
@@ -81,9 +72,9 @@ The release implementation should use a reusable workflow plus thin product-spec
 
 Required behavior:
 
-1. Wrapper workflow listens for the chart-specific slash command.
-2. Reusable workflow validates PR state and changed-file scope.
-3. Workflow checks out the PR head SHA.
+1. Wrapper workflow exposes a manual `workflow_dispatch` entrypoint only.
+2. Reusable workflow validates that the dispatch runs from `master`.
+3. Workflow checks out the current `master` commit.
 4. Workflow reads the chart version from `Chart.yaml`.
 5. Workflow creates and pushes the chart-specific Git tag.
 6. Workflow packages and publishes only the target chart.
@@ -126,7 +117,7 @@ Implementation requirement:
 The release workflow must not:
 
 - release all charts in the repository by default
-- infer the target chart from any changed folder automatically without an explicit trigger
+- infer the target chart from any changed folder automatically
 - share a generic `/release` command across unrelated products
 
 ## Acceptance Criteria
@@ -137,7 +128,7 @@ The implementation is complete when:
 - the existing Redis Enterprise chart contents and release behavior remain unchanged
 - `ai/charts/redis-agent-memory` exists as a valid chart
 - a chart-scoped release workflow exists for `redis-agent-memory`
-- the workflow fails if the PR touches files outside `ai/charts/redis-agent-memory/`
+- the workflow can only be dispatched from `master`
 - the workflow tags releases as `redis-agent-memory-<version>`
 - only the target chart is packaged and published
 - the AI Helm repository publishes its own `gh-pages/ai/index.yaml` without modifying the Redis Enterprise Helm repository index


### PR DESCRIPTION
## Summary
- switch redis-agent-memory release to manual workflow_dispatch only
- require releases to run from master in the reusable AI release workflow
- restore the proven AI chart publishing flow for tags, releases, and gh-pages/ai/index.yaml
- add ai/README.md with change, validation, and release instructions
- align docs/ai-helm-repo-spec.md with the manual release model

## Validation
- manually dispatched the release workflow during validation
- verified GitHub release creation and gh-pages/ai/index.yaml publication
- verified https://helm.redis.io/ai/index.yaml serves the AI Helm index
- verified Helm can discover and pull the published chart
