### PR TITLE
MOD-16629: Add release workflow for redis-context-retriever chart

### DIFF
--- a/.github/workflows/release-redis-context-retriever.yaml
+++ b/.github/workflows/release-redis-context-retriever.yaml
@@ -1,0 +1,13 @@
+name: Release Redis Context Retriever Chart
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-release-workflow:
+    uses: ./.github/workflows/release-chart-reusable.yaml
+    with:
+      chart_name: redis-context-retriever
+      chart_path: ai/charts/redis-context-retriever
+      tag_prefix: redis-context-retriever
+    secrets: inherit


### PR DESCRIPTION
## What

Adds `.github/workflows/release-redis-context-retriever.yaml` — the publish wrapper for the new **Context Retriever** on-prem Helm chart, mirroring the existing `release-redis-agent-memory.yaml`. It calls `release-chart-reusable.yaml` with `chart_name` / `chart_path` / `tag_prefix` = `redis-context-retriever`, so the `ai/charts/redis-context-retriever` chart can be published to `helm.redis.io/ai`.

## Why

Context Retriever (cloud-context-engine) is adopting the same connected on-prem release model as Agent Memory: its release workflow opens a chart-sync PR into this repo at `ai/charts/redis-context-retriever`, and this workflow is what publishes that chart to the public Helm repo. Without it there's no publish step for the new chart.

Source: redislabsdev/cloud-context-engine (MOD-16629).

🤖 Generated with [Claude Code](https://claude.com/claude-code)